### PR TITLE
Add invalid name validation tests

### DIFF
--- a/src/main/kotlin/com/example/demo/dto/ExampleDto.kt
+++ b/src/main/kotlin/com/example/demo/dto/ExampleDto.kt
@@ -2,17 +2,23 @@ package com.example.demo.dto
 
 import com.example.demo.validation.OnCreate
 import com.example.demo.validation.OnUpdate
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 
 data class ExampleDto(
     var id: Long? = null,
+
     @field:NotBlank(groups = [OnCreate::class], message = "Name is required for creation")
+    @field:Schema(
+        example = "Sample Name"
+    )
     @field:Pattern(
         regexp = "^[A-Za-z0-9 ]+$",
         groups = [OnCreate::class, OnUpdate::class],
         message = "Name can only contain letters, numbers, and spaces"
     )
     var name: String? = null,
+
     var description: String? = null
 )

--- a/src/main/kotlin/com/example/demo/dto/ExampleDto.kt
+++ b/src/main/kotlin/com/example/demo/dto/ExampleDto.kt
@@ -1,11 +1,18 @@
 package com.example.demo.dto
 
 import com.example.demo.validation.OnCreate
+import com.example.demo.validation.OnUpdate
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
 
 data class ExampleDto(
     var id: Long? = null,
     @field:NotBlank(groups = [OnCreate::class], message = "Name is required for creation")
+    @field:Pattern(
+        regexp = "^[A-Za-z0-9 ]+$",
+        groups = [OnCreate::class, OnUpdate::class],
+        message = "Name can only contain letters, numbers, and spaces"
+    )
     var name: String? = null,
     var description: String? = null
 )

--- a/src/test/kotlin/com/example/demo/ExampleControllerIntegrationTests.kt
+++ b/src/test/kotlin/com/example/demo/ExampleControllerIntegrationTests.kt
@@ -84,4 +84,48 @@ class ExampleControllerIntegrationTests @Autowired constructor(
         mockMvc.perform(get("/examples/999999"))
             .andExpect(status().isNotFound)
     }
+
+    @Test
+    fun `creating with invalid characters returns 400`() {
+        val invalidJson = """
+            {
+                "name": "Bad#Name"
+            }
+        """.trimIndent()
+
+        mockMvc.perform(
+            post("/examples")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidJson)
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `updating with invalid characters returns 400`() {
+        val createJson = """
+            {
+                "name": "GoodName"
+            }
+        """.trimIndent()
+
+        val createResult = mockMvc.perform(
+            post("/examples")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createJson)
+        ).andExpect(status().isCreated).andReturn()
+
+        val id = objectMapper.readTree(createResult.response.contentAsString)["id"].asLong()
+
+        val patchJson = """
+            {
+                "name": "Bad#Name"
+            }
+        """.trimIndent()
+
+        mockMvc.perform(
+            patch("/examples/$id")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(patchJson)
+        ).andExpect(status().isBadRequest)
+    }
 }


### PR DESCRIPTION
## Summary
- enforce name pattern to allow only alphanumerics and spaces
- add integration tests covering invalid characters for POST and PATCH

## Testing
- `./gradlew test --no-daemon --console=plain`
